### PR TITLE
Safety guardrails: enforce testnet + read-only default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,19 @@ binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET -
 
 ## Rate Limiting
 
-- Weighted token-bucket aligned with Binance weights (approximate).
-- Depth endpoint cost scales with `limit` (2..50).
-- Configure capacity via env: `BINANCE_WEIGHT_LIMIT_PER_MINUTE` (future), current default ~1200/min.
+- Weighted token-bucket aligned s Binance weights (approximate).
+- Separate limiters:
+  - Spot: `BINANCE_SPOT_WEIGHT_LIMIT_PER_MINUTE` (default 1200)
+  - Futures: `BINANCE_FUTURES_WEIGHT_LIMIT_PER_MINUTE` (default 1200)
+- Endpoint weights (defaults):
+  - Depth `/depth`: by `limit` → 2/5/10/20/50
+  - 24h ticker `/ticker/24hr`: 1
+  - Price `/ticker/price`: 1
+  - Exchange info `/exchangeInfo`: 10
+  - Account `/account`: 10
+  - Orders `/allOrders`: 10
+  - New order `/order`: 1
+  - Futures account/positions: 5
 
 ## Symbol Validation (optional)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ export BINANCE_TESTNET="true"
 
 ```bash
 # Start the MCP server (after installing from PyPI)
-binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET --binance-testnet
+# By default the server runs in READ-ONLY mode (trading disabled)
+binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET --binance-testnet --read-only
+
+# To enable trading tools explicitly, pass --enable-trading (recommended only on testnet)
+# binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET --binance-testnet --enable-trading
 ```
 
 ### 4️⃣ Connect Your AI Agent

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET -
 
 # To enable trading tools explicitly, pass --enable-trading (recommended only on testnet)
 # binance-mcp-server --api-key $BINANCE_API_KEY --api-secret $BINANCE_API_SECRET --binance-testnet --enable-trading
+
+## Capabilities & Environment
+
+- Trading (state-changing):
+  - Default: disabled
+  - Enable via CLI `--enable-trading` or env `BINANCE_MCP_ENABLE_TRADING=true`
+  - `BINANCE_MCP_READ_ONLY=true` will always disable trading
+
+- Wallet (sensitive account info like deposit/withdraw endpoints):
+  - Default: disabled
+  - Enable via env `BINANCE_MCP_ENABLE_WALLET=true`
+
+- Account (balances, positions, PnL):
+  - Default: enabled
+  - Can be disabled via env `BINANCE_MCP_ENABLE_ACCOUNT=false`
+
+## Rate Limiting
+
+- Weighted token-bucket aligned with Binance weights (approximate).
+- Depth endpoint cost scales with `limit` (2..50).
+- Configure capacity via env: `BINANCE_WEIGHT_LIMIT_PER_MINUTE` (future), current default ~1200/min.
+
+## Symbol Validation (optional)
+
+- Enable existence checks with `BINANCE_MCP_VALIDATE_SYMBOL_EXISTS=true` (uses cached exchange info, TTL 15m).
 ```
 
 ### 4️⃣ Connect Your AI Agent

--- a/binance_mcp_server/cli.py
+++ b/binance_mcp_server/cli.py
@@ -55,6 +55,11 @@ def binance_mcp_server(
         "--transport",
         help="Transport method to use (stdio, streamable-http, or sse)"
     ),
+    read_only: bool = typer.Option(
+        True,
+        "--read-only/--enable-trading",
+        help="Run server in read-only mode (disable trading tools)"
+    ),
     port: int = typer.Option(
         8000,
         "--port",
@@ -83,6 +88,8 @@ def binance_mcp_server(
         os.environ["BINANCE_API_SECRET"] = api_secret
     if binance_testnet:
         os.environ["BINANCE_TESTNET"] = str(binance_testnet).lower()
+    # Read-only guardrail env
+    os.environ["BINANCE_MCP_READ_ONLY"] = str(read_only).lower()
     
     # Initialize and validate configuration
     config = BinanceConfig()
@@ -103,6 +110,7 @@ def binance_mcp_server(
     typer.echo(f"📡 Transport: {transport.value.upper()}")
     typer.echo(f"🌐 Environment: {'Testnet' if config.testnet else 'Production'}")
     typer.echo(f"🔗 Base URL: {config.base_url}")
+    typer.echo(f"🔒 Mode: {'Read-only' if read_only else 'Trading enabled'}")
     
     if transport in [TransportType.streamable_http, TransportType.sse]:
         typer.echo(f"Server: http://{host}:{port}")

--- a/binance_mcp_server/server.py
+++ b/binance_mcp_server/server.py
@@ -13,7 +13,7 @@ import argparse
 from typing import Dict, Any, Optional
 from fastmcp import FastMCP
 from dotenv import load_dotenv
-from binance_mcp_server.security import SecurityConfig, validate_api_credentials, security_audit_log
+from binance_mcp_server.security import SecurityConfig, validate_api_credentials, security_audit_log, require_capability
 
 
 logging.basicConfig(
@@ -326,6 +326,7 @@ def get_pnl() -> Dict[str, Any]:
 
 
 @mcp.tool()
+@require_capability("TRADING")
 def create_order(
     symbol: str,
     side: str,
@@ -347,16 +348,7 @@ def create_order(
         Dictionary containing success status and order data.
     """
     logger.info(f"Tool called: create_order with symbol={symbol}, side={side}, type={order_type}, quantity={quantity}, price={price}")
-    # Read-only guardrail (default ON). Disable by setting BINANCE_MCP_READ_ONLY=false
-    read_only = os.getenv("BINANCE_MCP_READ_ONLY", "true").lower() == "true"
-    if read_only:
-        return {
-            "success": False,
-            "error": {
-                "type": "forbidden",
-                "message": "Trading is disabled (read-only mode). Set BINANCE_MCP_READ_ONLY=false or start with --enable-trading."
-            }
-        }
+    # Gating handled by @require_capability("TRADING")
     
     try:
         from binance_mcp_server.tools.create_order import create_order as _create_order
@@ -414,6 +406,7 @@ def get_liquidation_history() -> Dict[str, Any]:
         }
 
 @mcp.tool()
+@require_capability("WALLET")
 def get_deposit_address(coin: str) -> Dict[str, Any]:
     """
     Get the deposit address for a specific coin on the user's Binance account.
@@ -449,6 +442,7 @@ def get_deposit_address(coin: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@require_capability("WALLET")
 def get_deposit_history(coin: str) -> Dict[str, Any]:
     """
     Get the deposit history for a specific coin on the user's Binance account.
@@ -484,6 +478,7 @@ def get_deposit_history(coin: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@require_capability("WALLET")
 def get_withdraw_history(coin: str) -> Dict[str, Any]:
     """
     Get the withdrawal history for the user's Binance account.

--- a/binance_mcp_server/tools/create_order.py
+++ b/binance_mcp_server/tools/create_order.py
@@ -13,18 +13,19 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
-    validate_symbol,
+    binance_spot_rate_limiter,
+    validate_symbol_exists,
     validate_and_get_order_side,
     validate_and_get_order_type,
-    validate_positive_number
+    validate_positive_number,
+    estimate_weight_for_create_order,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda *args, **kwargs: estimate_weight_for_create_order())
 def create_order(symbol: str, side: str, order_type: str, quantity: float, price: Optional[float] = None) -> Dict[str, Any]:
     """
     Create a new trading order on Binance.
@@ -78,7 +79,7 @@ def create_order(symbol: str, side: str, order_type: str, quantity: float, price
         client = get_binance_client()
         
         # Enhanced input validation
-        normalized_symbol = validate_symbol(symbol)
+        normalized_symbol = validate_symbol_exists(symbol)
         validated_side = validate_and_get_order_side(side)
         validated_order_type = validate_and_get_order_type(order_type)
         

--- a/binance_mcp_server/tools/get_account_snapshot.py
+++ b/binance_mcp_server/tools/get_account_snapshot.py
@@ -13,15 +13,16 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
     # validate_and_get_account_type
+    estimate_weight_for_account,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda: estimate_weight_for_account())
 def get_account_snapshot(account_type: str) -> Dict[str, Any]:
     """
     Get a point-in-time account snapshot for the user's Binance account.

--- a/binance_mcp_server/tools/get_available_assets.py
+++ b/binance_mcp_server/tools/get_available_assets.py
@@ -8,18 +8,19 @@ import logging
 from typing import Dict, Any
 from binance.exceptions import BinanceAPIException, BinanceRequestException
 from binance_mcp_server.utils import (
-    get_binance_client, 
-    create_error_response, 
+    get_binance_client,
+    create_error_response,
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
+    estimate_weight_for_exchange_info,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda: estimate_weight_for_exchange_info())
 def get_available_assets() -> Dict[str, Any]:
     """
     Get a comprehensive list of all available trading assets and symbols on Binance.

--- a/binance_mcp_server/tools/get_balance.py
+++ b/binance_mcp_server/tools/get_balance.py
@@ -13,14 +13,15 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
+    estimate_weight_for_account,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda: estimate_weight_for_account())
 def get_balance() -> Dict[str, Any]:
     """
     Get the current account balance for all assets on Binance.

--- a/binance_mcp_server/tools/get_deposit_address.py
+++ b/binance_mcp_server/tools/get_deposit_address.py
@@ -13,14 +13,14 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=1)
 def get_deposit_address(coin: str) -> Dict[str, Any]:
     """
     Get the deposit address for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/tools/get_deposit_address.py
+++ b/binance_mcp_server/tools/get_deposit_address.py
@@ -13,14 +13,14 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_spot_rate_limiter,
+    binance_sapi_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_spot_rate_limiter, cost=1)
+@rate_limited(binance_sapi_rate_limiter, cost=1)
 def get_deposit_address(coin: str) -> Dict[str, Any]:
     """
     Get the deposit address for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/tools/get_deposit_history.py
+++ b/binance_mcp_server/tools/get_deposit_history.py
@@ -9,18 +9,18 @@ import logging
 from typing import Dict, Any, Optional
 from binance.exceptions import BinanceAPIException, BinanceRequestException
 from binance_mcp_server.utils import (
-    get_binance_client, 
-    create_error_response, 
+    get_binance_client,
+    create_error_response,
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=1)
 def get_deposit_history(coin: str) -> Dict[str, Any]:
     """
     Get the deposit transaction history for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/tools/get_deposit_history.py
+++ b/binance_mcp_server/tools/get_deposit_history.py
@@ -13,14 +13,14 @@ from binance_mcp_server.utils import (
     create_error_response,
     create_success_response,
     rate_limited,
-    binance_spot_rate_limiter,
+    binance_sapi_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_spot_rate_limiter, cost=1)
+@rate_limited(binance_sapi_rate_limiter, cost=1)
 def get_deposit_history(coin: str) -> Dict[str, Any]:
     """
     Get the deposit transaction history for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/tools/get_fee_info.py
+++ b/binance_mcp_server/tools/get_fee_info.py
@@ -13,14 +13,15 @@ from binance_mcp_server.utils import (
     create_error_response,
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
     validate_symbol,
+    estimate_weight_for_trade_fee,
 )
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda: estimate_weight_for_trade_fee())
 def get_fee_info(symbol: Optional[str] = None) -> Dict[str, Any]:
     """
     Get trading fee information for symbols on Binance.

--- a/binance_mcp_server/tools/get_order_book.py
+++ b/binance_mcp_server/tools/get_order_book.py
@@ -14,14 +14,15 @@ from binance_mcp_server.utils import (
     create_success_response,
     rate_limited,
     binance_rate_limiter,
-    validate_symbol,
+    validate_symbol_exists,
     validate_limit_parameter,
+    estimate_weight_for_depth,
 )
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_rate_limiter, cost=lambda symbol, limit=None: estimate_weight_for_depth(limit))
 def get_order_book(symbol: str, limit: Optional[int] = None) -> Dict[str, Any]:
     """
     Get the current order book (bids/asks) for a trading symbol on Binance.
@@ -61,7 +62,7 @@ def get_order_book(symbol: str, limit: Optional[int] = None) -> Dict[str, Any]:
     
     try:
         # Validate and normalize symbol
-        normalized_symbol = validate_symbol(symbol)
+        normalized_symbol = validate_symbol_exists(symbol)
         
         # Validate limit parameter using enhanced validation
         validated_limit = validate_limit_parameter(limit, max_limit=5000)

--- a/binance_mcp_server/tools/get_orders.py
+++ b/binance_mcp_server/tools/get_orders.py
@@ -9,19 +9,20 @@ import logging
 from typing import Dict, Any, Optional
 from binance.exceptions import BinanceAPIException, BinanceRequestException
 from binance_mcp_server.utils import (
-    get_binance_client, 
-    create_error_response, 
+    get_binance_client,
+    create_error_response,
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
-    validate_symbol
+    binance_spot_rate_limiter,
+    validate_symbol_exists,
+    estimate_weight_for_all_orders,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda *args, **kwargs: estimate_weight_for_all_orders())
 def get_orders(symbol: str, start_time: Optional[int] = None, end_time: Optional[int] = None) -> Dict[str, Any]:
     """
     Get all orders for a specific trading symbol on Binance.
@@ -75,7 +76,7 @@ def get_orders(symbol: str, start_time: Optional[int] = None, end_time: Optional
 
     try:
         
-        normalized_symbol = validate_symbol(symbol)
+        normalized_symbol = validate_symbol_exists(symbol)
         
         client = get_binance_client()
 

--- a/binance_mcp_server/tools/get_pnl.py
+++ b/binance_mcp_server/tools/get_pnl.py
@@ -13,15 +13,16 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
-    validate_symbol
+    binance_futures_rate_limiter,
+    validate_symbol,
+    estimate_weight_for_futures_account,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_futures_rate_limiter, cost=lambda: estimate_weight_for_futures_account())
 def get_pnl() -> Dict[str, Any]:
     """
     Get the current profit and loss (P&L) information for the user's Binance futures account.

--- a/binance_mcp_server/tools/get_position_info.py
+++ b/binance_mcp_server/tools/get_position_info.py
@@ -13,15 +13,16 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
-    validate_symbol
+    binance_futures_rate_limiter,
+    validate_symbol,
+    estimate_weight_for_position_info,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_futures_rate_limiter, cost=lambda: estimate_weight_for_position_info())
 def get_position_info() -> Dict[str, Any]:
     """
     Get the current position information for the user's Binance futures account.

--- a/binance_mcp_server/tools/get_ticker.py
+++ b/binance_mcp_server/tools/get_ticker.py
@@ -10,18 +10,19 @@ from typing import Dict, Any
 from binance.exceptions import BinanceAPIException, BinanceRequestException
 from binance_mcp_server.utils import  (
     get_binance_client, 
-    validate_symbol, 
+    validate_symbol_exists, 
     rate_limited, 
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
     create_success_response,
-    create_error_response
+    create_error_response,
+    estimate_weight_for_24hr_ticker,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=lambda symbol: estimate_weight_for_24hr_ticker())
 def get_ticker(symbol: str) -> Dict[str, Any]:
     """
     Get 24-hour ticker price change statistics for a symbol.
@@ -47,7 +48,7 @@ def get_ticker(symbol: str) -> Dict[str, Any]:
 
     try:
         
-        normalized_symbol = validate_symbol(symbol)
+        normalized_symbol = validate_symbol_exists(symbol)
         
         client = get_binance_client()
         ticker = client.get_ticker(symbol=normalized_symbol)

--- a/binance_mcp_server/tools/get_ticker_price.py
+++ b/binance_mcp_server/tools/get_ticker_price.py
@@ -14,14 +14,14 @@ from binance_mcp_server.utils import (
     create_success_response,
     rate_limited,
     binance_rate_limiter,
-    validate_symbol
+    validate_symbol_exists
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_rate_limiter, cost=1)
 def get_ticker_price(symbol: str) -> Dict[str, Any]:
     """
     Get the current price for a trading symbol on Binance.
@@ -49,7 +49,7 @@ def get_ticker_price(symbol: str) -> Dict[str, Any]:
     logger.info(f"Fetching ticker price for symbol: {symbol}")
     
     try:
-        normalized_symbol = validate_symbol(symbol)
+        normalized_symbol = validate_symbol_exists(symbol)
         
         client = get_binance_client()
         

--- a/binance_mcp_server/tools/get_ticker_price.py
+++ b/binance_mcp_server/tools/get_ticker_price.py
@@ -13,15 +13,16 @@ from binance_mcp_server.utils import (
     create_error_response, 
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
-    validate_symbol_exists
+    binance_spot_rate_limiter,
+    validate_symbol_exists,
+    estimate_weight_for_ticker,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter, cost=1)
+@rate_limited(binance_spot_rate_limiter, cost=lambda symbol: estimate_weight_for_ticker())
 def get_ticker_price(symbol: str) -> Dict[str, Any]:
     """
     Get the current price for a trading symbol on Binance.

--- a/binance_mcp_server/tools/get_withdraw_history.py
+++ b/binance_mcp_server/tools/get_withdraw_history.py
@@ -9,18 +9,18 @@ import logging
 from typing import Dict, Any, Optional
 from binance.exceptions import BinanceAPIException, BinanceRequestException
 from binance_mcp_server.utils import (
-    get_binance_client, 
-    create_error_response, 
+    get_binance_client,
+    create_error_response,
     create_success_response,
     rate_limited,
-    binance_rate_limiter,
+    binance_spot_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_rate_limiter)
+@rate_limited(binance_spot_rate_limiter, cost=1)
 def get_withdraw_history(coin: str) -> Dict[str, Any]:
     """
     Get the withdrawal transaction history for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/tools/get_withdraw_history.py
+++ b/binance_mcp_server/tools/get_withdraw_history.py
@@ -13,14 +13,14 @@ from binance_mcp_server.utils import (
     create_error_response,
     create_success_response,
     rate_limited,
-    binance_spot_rate_limiter,
+    binance_sapi_rate_limiter,
 )
 
 
 logger = logging.getLogger(__name__)
 
 
-@rate_limited(binance_spot_rate_limiter, cost=1)
+@rate_limited(binance_sapi_rate_limiter, cost=1)
 def get_withdraw_history(coin: str) -> Dict[str, Any]:
     """
     Get the withdrawal transaction history for a specific cryptocurrency on the user's Binance account.

--- a/binance_mcp_server/utils.py
+++ b/binance_mcp_server/utils.py
@@ -113,16 +113,27 @@ def get_binance_client() -> Client:
     config = get_config()
     
     try:
-        # Create client with appropriate configuration
+        # Create client
         client = Client(
             api_key=config.api_key,
             api_secret=config.api_secret,
-            # testnet=config.testnet
         )
-        
+
+        # Explicitly route to testnet endpoints when requested
+        if config.testnet:
+            try:
+                # Spot testnet base URL
+                if hasattr(client, "API_URL"):
+                    client.API_URL = "https://testnet.binance.vision/api"
+                # USD‑M Futures testnet base URL
+                if hasattr(client, "FUTURES_URL"):
+                    client.FUTURES_URL = "https://testnet.binancefuture.com/fapi"
+            except Exception as e:
+                logger.warning(f"Failed to set testnet endpoints on client: {e}")
+
         # Test connection
         client.ping()
-        
+
         logger.info(f"Successfully initialized Binance client (testnet: {config.testnet})")
         return client
         

--- a/binance_mcp_server/utils.py
+++ b/binance_mcp_server/utils.py
@@ -564,8 +564,22 @@ def validate_limit_parameter(limit: Optional[int], max_limit: int = 5000) -> Opt
 
 
 
-# Global weighted rate limiter instance
-binance_rate_limiter = WeightedRateLimiter(capacity=1200, refill_per_minute=1200)
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except Exception:
+        return default
+
+
+# Separate spot vs. futures limiters (approximate defaults)
+_SPOT_PER_MIN = _env_int("BINANCE_SPOT_WEIGHT_LIMIT_PER_MINUTE", 1200)
+_FUT_PER_MIN = _env_int("BINANCE_FUTURES_WEIGHT_LIMIT_PER_MINUTE", 1200)
+
+binance_spot_rate_limiter = WeightedRateLimiter(capacity=_SPOT_PER_MIN, refill_per_minute=_SPOT_PER_MIN)
+binance_futures_rate_limiter = WeightedRateLimiter(capacity=_FUT_PER_MIN, refill_per_minute=_FUT_PER_MIN)
+
+# Backward compatibility alias
+binance_rate_limiter = binance_spot_rate_limiter
 
 
 def estimate_weight_for_depth(limit: Optional[int]) -> int:
@@ -586,3 +600,39 @@ def estimate_weight_for_depth(limit: Optional[int]) -> int:
     if l <= 1000:
         return 20
     return 50
+
+
+def estimate_weight_for_ticker() -> int:
+    return 1
+
+
+def estimate_weight_for_24hr_ticker() -> int:
+    return 1
+
+
+def estimate_weight_for_exchange_info() -> int:
+    return 10
+
+
+def estimate_weight_for_account() -> int:
+    return 10
+
+
+def estimate_weight_for_all_orders() -> int:
+    return 10
+
+
+def estimate_weight_for_create_order() -> int:
+    return 1
+
+
+def estimate_weight_for_trade_fee() -> int:
+    return 1
+
+
+def estimate_weight_for_futures_account() -> int:
+    return 5
+
+
+def estimate_weight_for_position_info() -> int:
+    return 5

--- a/binance_mcp_server/utils.py
+++ b/binance_mcp_server/utils.py
@@ -6,8 +6,9 @@ client initialization, rate limiting, and error handling utilities.
 """
 
 import time
+import os
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Callable, Iterable
 from functools import wraps
 from binance.client import Client
 from binance.exceptions import BinanceAPIException, BinanceRequestException
@@ -151,41 +152,33 @@ def get_binance_client() -> Client:
         raise RuntimeError(error_msg) from e
 
 
-class RateLimiter:
+class WeightedRateLimiter:
     """
-    Rate limiter for API calls to respect Binance limits.
+    Token-bucket weighted rate limiter.
 
-    Binance has strict rate limits (1200 requests per minute for most endpoints).
-    This class helps prevent rate limit violations.
+    Defaults to Binance spot limit ~1200 weight/min.
     """
-    
-    def __init__(self, max_calls: int = 1200, window: int = 60):
-        """
-        Initialize rate limiter.
-        
-        Args:
-            max_calls: Maximum number of calls allowed in the time window
-            window: Time window in seconds
-        """
-        self.max_calls = max_calls
-        self.window = window
-        self.calls = []
-    
-    def can_proceed(self) -> bool:
-        """
-        Check if we can make another API call without violating rate limits.
-        
-        Returns:
-            bool: True if call can proceed, False if rate limited
-        """
+
+    def __init__(self, capacity: int = 1200, refill_per_minute: int = 1200):
+        self.capacity = max(1, capacity)
+        self.refill_rate = max(1, refill_per_minute) / 60.0  # tokens per second
+        self.tokens = float(self.capacity)
+        self.last_refill = time.time()
+
+    def _refill(self) -> None:
         now = time.time()
-        
-        self.calls = [call_time for call_time in self.calls if now - call_time < self.window]
-        
-        if len(self.calls) < self.max_calls:
-            self.calls.append(now)
+        elapsed = now - self.last_refill
+        if elapsed <= 0:
+            return
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.refill_rate)
+        self.last_refill = now
+
+    def try_consume(self, cost: int = 1) -> bool:
+        self._refill()
+        c = max(1, int(cost))
+        if self.tokens >= c:
+            self.tokens -= c
             return True
-            
         return False
 
 
@@ -303,23 +296,43 @@ def create_success_response(data: Any, metadata: Optional[Dict] = None) -> Dict[
     return response
 
 
-def rate_limited(rate_limiter: Optional[RateLimiter] = None):
+def rate_limited(rate_limiter: Optional[object] = None, *, cost: Optional[Callable[..., int] | int] = None):
     """
     Decorator to apply rate limiting to functions.
     
     Args:
         rate_limiter: Optional custom rate limiter instance
+        cost: Optional constant int cost or callable(*args, **kwargs) -> int
     """
     if rate_limiter is None:
-        rate_limiter = RateLimiter(max_calls=1200, window=60)
+        rate_limiter = WeightedRateLimiter(capacity=1200, refill_per_minute=1200)
     
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if not rate_limiter.can_proceed():
+            # Determine weight cost
+            if callable(cost):
+                try:
+                    weight = int(cost(*args, **kwargs))
+                except Exception:
+                    weight = 1
+            elif isinstance(cost, int):
+                weight = max(1, cost)
+            else:
+                weight = 1
+
+            # Support both old and new limiter interfaces
+            allowed = False
+            if hasattr(rate_limiter, "try_consume"):
+                allowed = rate_limiter.try_consume(weight)
+            elif hasattr(rate_limiter, "can_proceed"):
+                allowed = rate_limiter.can_proceed()
+
+            if not allowed:
                 return create_error_response(
                     "rate_limit_exceeded",
-                    "API rate limit exceeded. Please try again later."
+                    "API rate limit exceeded. Please try again later.",
+                    details={"weight": weight}
                 )
             return func(*args, **kwargs)
         return wrapper
@@ -367,6 +380,43 @@ def validate_symbol(symbol: str) -> str:
         raise ValueError("Symbol cannot start with a number or be purely numeric")
     
     return sanitized_symbol
+
+
+# Optional: symbol existence cache (opt-in)
+_SYMBOL_CACHE = {"ts": 0.0, "symbols": set()}
+
+
+def _cache_ttl_seconds() -> int:
+    try:
+        return int(os.getenv("BINANCE_SYMBOL_CACHE_TTL_SECONDS", "900"))
+    except Exception:
+        return 900
+
+
+def _ensure_symbol_cache(client: Client) -> None:
+    now = time.time()
+    if now - _SYMBOL_CACHE["ts"] < _cache_ttl_seconds():
+        return
+    info = client.get_exchange_info()
+    listed = {s["symbol"].upper() for s in info.get("symbols", []) if s.get("status") == "TRADING" or s.get("isSpotTradingAllowed")}
+    _SYMBOL_CACHE["symbols"] = listed
+    _SYMBOL_CACHE["ts"] = now
+
+
+def validate_symbol_exists(symbol: str) -> str:
+    """
+    Validate format and (optionally) that symbol is listed on the exchange.
+
+    Controlled by env BINANCE_MCP_VALIDATE_SYMBOL_EXISTS (default: false).
+    """
+    sym = validate_symbol(symbol)
+    if os.getenv("BINANCE_MCP_VALIDATE_SYMBOL_EXISTS", "false").lower() != "true":
+        return sym
+    client = get_binance_client()
+    _ensure_symbol_cache(client)
+    if sym not in _SYMBOL_CACHE["symbols"]:
+        raise ValueError(f"Symbol '{sym}' is not listed on Binance")
+    return sym
 
 
 def validate_and_get_order_side(side: str) -> Any:
@@ -514,5 +564,25 @@ def validate_limit_parameter(limit: Optional[int], max_limit: int = 5000) -> Opt
 
 
 
-# Global rate limiter instance
-binance_rate_limiter = RateLimiter(max_calls=1200, window=60)
+# Global weighted rate limiter instance
+binance_rate_limiter = WeightedRateLimiter(capacity=1200, refill_per_minute=1200)
+
+
+def estimate_weight_for_depth(limit: Optional[int]) -> int:
+    """Approximate Binance weight for GET /depth by limit."""
+    if limit is None:
+        return 5
+    try:
+        l = int(limit)
+    except Exception:
+        return 5
+    # Based on common Binance guidance; conservative
+    if l <= 50:
+        return 2
+    if l <= 100:
+        return 5
+    if l <= 500:
+        return 10
+    if l <= 1000:
+        return 20
+    return 50

--- a/binance_mcp_server/utils.py
+++ b/binance_mcp_server/utils.py
@@ -613,23 +613,29 @@ binance_rate_limiter = binance_spot_rate_limiter
 
 
 def estimate_weight_for_depth(limit: Optional[int]) -> int:
-    """Approximate Binance weight for GET /depth by limit."""
+    """Approximate Binance weight for GET /depth by limit (per official guidance)."""
     if limit is None:
-        return 5
+        # Default server limit is usually 100 → cost 10; use 10 as safe default
+        return 10
     try:
         l = int(limit)
     except Exception:
-        return 5
-    # Based on common Binance guidance; conservative
-    if l <= 50:
-        return 2
-    if l <= 100:
-        return 5
-    if l <= 500:
         return 10
+    # Official weights (typical):
+    # 5/10 → 1, 20 → 2, 50 → 5, 100 → 10, 500 → 50, 1000 → 100, 5000 → 500
+    if l <= 10:
+        return 1
+    if l <= 20:
+        return 2
+    if l <= 50:
+        return 5
+    if l <= 100:
+        return 10
+    if l <= 500:
+        return 50
     if l <= 1000:
-        return 20
-    return 50
+        return 100
+    return 500
 
 
 def estimate_weight_for_ticker() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "fastmcp>=2.5.1",
     "python-binance>=1.0.29",
     "typer>=0.16.0",
+    "python-dotenv>=1.0.1",
 ]
 
 [project.scripts]
@@ -26,3 +27,8 @@ binance-mcp-server = "binance_mcp_server.cli:app"
 
 [project.urls]
 Homepage = "https://analyticace.github.io/BinanceMCPServer/"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2",
+]

--- a/tests/test_multiwindow_rate_limiter.py
+++ b/tests/test_multiwindow_rate_limiter.py
@@ -1,0 +1,18 @@
+import time
+
+from binance_mcp_server.utils import MultiWindowRateLimiter
+
+
+def test_multiwindow_rate_limiter_basic():
+    # 6 per minute (~0.1 per sec), 2 per sec
+    rl = MultiWindowRateLimiter(per_minute=6, per_second=2)
+
+    # First second: allow up to 2 weight
+    assert rl.try_consume(1) is True
+    assert rl.try_consume(1) is True
+    assert rl.try_consume(1) is False  # second bucket exhausted
+
+    time.sleep(1.05)  # next second
+    # minute budget remaining: 6 - 2 = 4
+    assert rl.try_consume(2) is True
+    assert rl.try_consume(3) is False  # minute budget would exceed (only 2 left)

--- a/tests/test_weighted_rate_limiter.py
+++ b/tests/test_weighted_rate_limiter.py
@@ -1,0 +1,44 @@
+import os
+import math
+import time
+
+from binance_mcp_server.utils import (
+    WeightedRateLimiter,
+    rate_limited,
+    estimate_weight_for_depth,
+)
+
+
+def test_weighted_rate_limiter_basic():
+    rl = WeightedRateLimiter(capacity=10, refill_per_minute=60)  # 1 token/sec
+    assert rl.try_consume(5) is True
+    assert rl.try_consume(6) is False  # only 5 left
+    time.sleep(1.1)
+    assert rl.try_consume(1) is True
+
+
+def test_rate_limited_decorator_cost():
+    rl = WeightedRateLimiter(capacity=3, refill_per_minute=60)
+
+    calls = {"count": 0}
+
+    @rate_limited(rl, cost=2)
+    def f():
+        calls["count"] += 1
+        return {"ok": True}
+
+    r1 = f()
+    r2 = f()  # should fail due to insufficient tokens (3 capacity, first consumed 2, second wants 2)
+    assert r1.get("ok") is True
+    assert r2.get("success") is False
+    assert r2.get("error", {}).get("type") == "rate_limit_exceeded"
+
+
+def test_estimate_weight_for_depth():
+    assert estimate_weight_for_depth(None) in (2, 5, 10, 20, 50, 5)
+    assert estimate_weight_for_depth(5) == 2
+    assert estimate_weight_for_depth(100) == 5
+    assert estimate_weight_for_depth(500) == 10
+    assert estimate_weight_for_depth(1000) == 20
+    assert estimate_weight_for_depth(5000) == 50
+

--- a/tests/test_weighted_rate_limiter.py
+++ b/tests/test_weighted_rate_limiter.py
@@ -35,10 +35,12 @@ def test_rate_limited_decorator_cost():
 
 
 def test_estimate_weight_for_depth():
-    assert estimate_weight_for_depth(None) in (2, 5, 10, 20, 50, 5)
-    assert estimate_weight_for_depth(5) == 2
-    assert estimate_weight_for_depth(100) == 5
-    assert estimate_weight_for_depth(500) == 10
-    assert estimate_weight_for_depth(1000) == 20
-    assert estimate_weight_for_depth(5000) == 50
-
+    assert estimate_weight_for_depth(None) == 10  # default (assume 100)
+    assert estimate_weight_for_depth(5) == 1
+    assert estimate_weight_for_depth(10) == 1
+    assert estimate_weight_for_depth(20) == 2
+    assert estimate_weight_for_depth(50) == 5
+    assert estimate_weight_for_depth(100) == 10
+    assert estimate_weight_for_depth(500) == 50
+    assert estimate_weight_for_depth(1000) == 100
+    assert estimate_weight_for_depth(5000) == 500

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -153,20 +153,29 @@ wheels = [
 
 [[package]]
 name = "binance-mcp-server"
-version = "1.2.4"
+version = "1.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "python-binance" },
+    { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.5.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2" },
     { name = "python-binance", specifier = ">=1.0.29" },
+    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "typer", specifier = ">=0.16.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "certifi"
@@ -455,6 +464,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -602,6 +620,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -854,6 +890,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/1d/eb34f286b164c5e431a810a38697409cca1112cee04b287bb56ac486730b/pytest-9.0.0.tar.gz", hash = "sha256:8f44522eafe4137b0f35c9ce3072931a788a21ee40a2ed279e817d3cc16ed21e", size = 1562764, upload-time = "2025-11-08T17:25:33.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/99/cafef234114a3b6d9f3aaed0723b437c40c57bdb7b3e4c3a575bc4890052/pytest-9.0.0-py3-none-any.whl", hash = "sha256:e5ccdf10b0bac554970ee88fc1a4ad0ee5d221f8ef22321f9b7e4584e19d7f96", size = 373364, upload-time = "2025-11-08T17:25:31.811Z" },
+]
+
+[[package]]
 name = "python-binance"
 version = "1.0.29"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,6 +1111,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236, upload-time = "2025-10-08T22:01:00.137Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7f/d8fffe6a7aefdb61bced88fcb5e280cfd71e08939da5894161bd71bea022/tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba", size = 148084, upload-time = "2025-10-08T22:01:01.63Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/24935fb6a2ee63e86d80e4d3b58b222dafaf438c416752c8b58537c8b89a/tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf", size = 234832, upload-time = "2025-10-08T22:01:02.543Z" },
+    { url = "https://files.pythonhosted.org/packages/89/da/75dfd804fc11e6612846758a23f13271b76d577e299592b4371a4ca4cd09/tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441", size = 242052, upload-time = "2025-10-08T22:01:03.836Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/f48ac899f7b3ca7eb13af73bacbc93aec37f9c954df3c08ad96991c8c373/tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845", size = 239555, upload-time = "2025-10-08T22:01:04.834Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/28/72f8afd73f1d0e7829bfc093f4cb98ce0a40ffc0cc997009ee1ed94ba705/tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c", size = 245128, upload-time = "2025-10-08T22:01:05.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/eb/a7679c8ac85208706d27436e8d421dfa39d4c914dcf5fa8083a9305f58d9/tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456", size = 96445, upload-time = "2025-10-08T22:01:06.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/fe/3d3420c4cb1ad9cb462fb52967080575f15898da97e21cb6f1361d505383/tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be", size = 107165, upload-time = "2025-10-08T22:01:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b7/40f36368fcabc518bb11c8f06379a0fd631985046c038aca08c6d6a43c6e/tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac", size = 154891, upload-time = "2025-10-08T22:01:09.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3f/d9dd692199e3b3aab2e4e4dd948abd0f790d9ded8cd10cbaae276a898434/tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22", size = 148796, upload-time = "2025-10-08T22:01:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/83/59bff4996c2cf9f9387a0f5a3394629c7efa5ef16142076a23a90f1955fa/tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f", size = 242121, upload-time = "2025-10-08T22:01:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e5/7c5119ff39de8693d6baab6c0b6dcb556d192c165596e9fc231ea1052041/tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52", size = 250070, upload-time = "2025-10-08T22:01:12.498Z" },
+    { url = "https://files.pythonhosted.org/packages/45/12/ad5126d3a278f27e6701abde51d342aa78d06e27ce2bb596a01f7709a5a2/tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8", size = 245859, upload-time = "2025-10-08T22:01:13.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a1/4d6865da6a71c603cfe6ad0e6556c73c76548557a8d658f9e3b142df245f/tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6", size = 250296, upload-time = "2025-10-08T22:01:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/b7/a7a7042715d55c9ba6e8b196d65d2cb662578b4d8cd17d882d45322b0d78/tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876", size = 97124, upload-time = "2025-10-08T22:01:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/f22f100db15a68b520664eb3328fb0ae4e90530887928558112c8d1f4515/tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878", size = 107698, upload-time = "2025-10-08T22:01:16.51Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/06ee6eabe4fdd9ecd48bf488f4ac783844fd777f547b8d1b61c11939974e/tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b", size = 154819, upload-time = "2025-10-08T22:01:17.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/88793757d54d8937015c75dcdfb673c65471945f6be98e6a0410fba167ed/tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae", size = 148766, upload-time = "2025-10-08T22:01:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/17/5e2c956f0144b812e7e107f94f1cc54af734eb17b5191c0bbfb72de5e93e/tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b", size = 240771, upload-time = "2025-10-08T22:01:20.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f4/0fbd014909748706c01d16824eadb0307115f9562a15cbb012cd9b3512c5/tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf", size = 248586, upload-time = "2025-10-08T22:01:21.164Z" },
+    { url = "https://files.pythonhosted.org/packages/30/77/fed85e114bde5e81ecf9bc5da0cc69f2914b38f4708c80ae67d0c10180c5/tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f", size = 244792, upload-time = "2025-10-08T22:01:22.417Z" },
+    { url = "https://files.pythonhosted.org/packages/55/92/afed3d497f7c186dc71e6ee6d4fcb0acfa5f7d0a1a2878f8beae379ae0cc/tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05", size = 248909, upload-time = "2025-10-08T22:01:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/ef50c51b5a9472e7265ce1ffc7f24cd4023d289e109f669bdb1553f6a7c2/tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606", size = 96946, upload-time = "2025-10-08T22:01:24.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/718cd1da0884f281f95ccfa3a6cc572d30053cba64603f79d431d3c9b61b/tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999", size = 107705, upload-time = "2025-10-08T22:01:26.153Z" },
+    { url = "https://files.pythonhosted.org/packages/19/94/aeafa14a52e16163008060506fcb6aa1949d13548d13752171a755c65611/tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e", size = 154244, upload-time = "2025-10-08T22:01:27.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/1e58409aa78eefa47ccd19779fc6f36787edbe7d4cd330eeeedb33a4515b/tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3", size = 148637, upload-time = "2025-10-08T22:01:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b6/d1eccb62f665e44359226811064596dd6a366ea1f985839c566cd61525ae/tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc", size = 241925, upload-time = "2025-10-08T22:01:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/70/91/7cdab9a03e6d3d2bb11beae108da5bdc1c34bdeb06e21163482544ddcc90/tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0", size = 249045, upload-time = "2025-10-08T22:01:31.98Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/8c26874ed1f6e4f1fcfeb868db8a794cbe9f227299402db58cfcc858766c/tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879", size = 245835, upload-time = "2025-10-08T22:01:32.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/42/8e3c6a9a4b1a1360c1a2a39f0b972cef2cc9ebd56025168c4137192a9321/tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005", size = 253109, upload-time = "2025-10-08T22:01:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/b4da635000a71b5f80130937eeac12e686eefb376b8dee113b4a582bba42/tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463", size = 97930, upload-time = "2025-10-08T22:01:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/74/cb1abc870a418ae99cd5c9547d6bce30701a954e0e721821df483ef7223c/tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8", size = 107964, upload-time = "2025-10-08T22:01:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/5c46fff6432a712af9f792944f4fcd7067d8823157949f4e40c56b8b3c83/tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77", size = 163065, upload-time = "2025-10-08T22:01:37.27Z" },
+    { url = "https://files.pythonhosted.org/packages/39/67/f85d9bd23182f45eca8939cd2bc7050e1f90c41f4a2ecbbd5963a1d1c486/tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf", size = 159088, upload-time = "2025-10-08T22:01:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5a/4b546a0405b9cc0659b399f12b6adb750757baf04250b148d3c5059fc4eb/tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530", size = 268193, upload-time = "2025-10-08T22:01:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4f/2c12a72ae22cf7b59a7fe75b3465b7aba40ea9145d026ba41cb382075b0e/tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b", size = 275488, upload-time = "2025-10-08T22:01:40.773Z" },
+    { url = "https://files.pythonhosted.org/packages/92/04/a038d65dbe160c3aa5a624e93ad98111090f6804027d474ba9c37c8ae186/tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67", size = 272669, upload-time = "2025-10-08T22:01:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2f/8b7c60a9d1612a7cbc39ffcca4f21a73bf368a80fc25bccf8253e2563267/tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f", size = 279709, upload-time = "2025-10-08T22:01:43.177Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds safety guardrails to the Binance MCP Server:

- Enforce real testnet routing (spot + futures) when `BINANCE_TESTNET=true`
- Read-only mode enabled by default; `create_order` returns `forbidden` unless `--enable-trading` or `BINANCE_MCP_READ_ONLY=false`
- CLI switch `--read-only/--enable-trading` + runtime banner
- Add `python-dotenv` to dependencies; add optional `dev` extras with `pytest`
- README Quick Start updated to show read-only default

Validation:
- `uv sync --extra dev`
- `uv run pytest -q` → 38 passed

Rationale:
- Prevent accidental live trading; allow explicit opt-in
- Ensure testnet flag actually changes endpoints

Follow-ups (optional):
- Consider weight-aware rate limiting for Binance limits
- Add WebSocket streams as MCP resources
- Add per-tool gating (e.g., wallet ops)
