### PR TITLE
Add get_funding_rates tool for perpetual futures

### DIFF
--- a/binance_mcp_server/server.py
+++ b/binance_mcp_server/server.py
@@ -66,6 +66,7 @@ mcp = FastMCP(
     
     Risk Management:
     - get_liquidation_history: Get liquidation history for futures trading
+    - get_funding_rates: Get funding rate history for perpetual futures contracts
     
     All operations implement:
     - Comprehensive input validation
@@ -627,6 +628,47 @@ def get_order_book(symbol: str, limit: Optional[int] = None) -> Dict[str, Any]:
         }
 
 
+@mcp.tool()
+def get_funding_rates(symbol: str, limit: Optional[int] = None) -> Dict[str, Any]:
+    """
+    Get funding rate history for a perpetual futures contract on Binance.
+
+    Funding rates are periodic payments between long and short traders in
+    perpetual futures markets. Positive rates mean longs pay shorts (bullish
+    crowding), negative rates mean shorts pay longs (bearish crowding).
+
+    Args:
+        symbol: Trading pair symbol (e.g., 'BTCUSDT', 'ETHUSDT')
+        limit: Number of records to return (default: 100, max: 1000)
+
+    Returns:
+        Dictionary containing funding rate history data.
+    """
+    logger.info(f"Tool called: get_funding_rates with symbol={symbol}, limit={limit}")
+
+    try:
+        from binance_mcp_server.tools.get_funding_rates import get_funding_rates as _get_funding_rates
+        result = _get_funding_rates(symbol, limit)
+
+        if result.get("success"):
+            count = result.get("data", {}).get("count", 0)
+            logger.info(f"Successfully fetched {count} funding rate entries for {symbol}")
+        else:
+            logger.warning(f"Failed to fetch funding rates for {symbol}: {result.get('error', {}).get('message')}")
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Unexpected error in get_funding_rates tool: {str(e)}")
+        return {
+            "success": False,
+            "error": {
+                "type": "tool_error",
+                "message": f"Tool execution failed: {str(e)}"
+            }
+        }
+
+
 
 def validate_configuration() -> bool:
     """
@@ -644,7 +686,7 @@ def validate_configuration() -> bool:
         if not config.is_valid():
             logger.error("Invalid Binance configuration:")
             for error in config.get_validation_errors():
-                logger.error(f"  • {error}")
+                logger.error(f"  â€¢ {error}")
             return False
         
         # Validate API credentials security
@@ -657,7 +699,7 @@ def validate_configuration() -> bool:
         if not security_config.is_secure():
             logger.warning("Security configuration warnings:")
             for warning in security_config.get_security_warnings():
-                logger.warning(f"  • {warning}")
+                logger.warning(f"  â€¢ {warning}")
             # Don't fail on security warnings, just log them
         
         # Log successful validation with security audit

--- a/binance_mcp_server/tools/get_funding_rates.py
+++ b/binance_mcp_server/tools/get_funding_rates.py
@@ -1,0 +1,103 @@
+"""
+Binance funding rate retrieval tool implementation.
+
+This module provides the get_funding_rates tool for fetching funding rate
+data for perpetual futures contracts on Binance.
+"""
+
+import logging
+from typing import Dict, Any, Optional
+from binance.exceptions import BinanceAPIException, BinanceRequestException
+from binance_mcp_server.utils import (
+    get_binance_client,
+    validate_symbol,
+    rate_limited,
+    binance_rate_limiter,
+    create_success_response,
+    create_error_response
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@rate_limited(binance_rate_limiter)
+def get_funding_rates(symbol: str, limit: Optional[int] = None) -> Dict[str, Any]:
+    """
+    Get funding rate history for a perpetual futures contract on Binance.
+
+    Funding rates are periodic payments between long and short traders in
+    perpetual futures markets. Positive rates mean longs pay shorts (bullish
+    crowding), negative rates mean shorts pay longs (bearish crowding).
+
+    Args:
+        symbol: Trading pair symbol (e.g., 'BTCUSDT', 'ETHUSDT')
+        limit: Number of records to return (default: 100, max: 1000)
+
+    Returns:
+        Dictionary containing funding rate data.
+        - success (bool): True if request was successful
+        - data (dict): Response data with current and historical rates
+        - timestamp (int): Unix timestamp of the response
+        - error (dict, optional): Error details if request failed
+
+    Examples:
+        result = get_funding_rates("BTCUSDT")
+        if result["success"]:
+            rates = result["data"]["history"]
+            current = rates[0] if rates else None
+            if current:
+                print(f"Current funding rate: {current['funding_rate']}")
+                print(f"Next funding time: {current['funding_time']}")
+    """
+    logger.info(f"Fetching funding rates for symbol: {symbol}")
+
+    try:
+        normalized_symbol = validate_symbol(symbol)
+
+        client = get_binance_client()
+
+        params = {"symbol": normalized_symbol}
+        if limit is not None:
+            params["limit"] = min(limit, 1000)
+
+        funding_history = client.futures_funding_rate(**params)
+
+        formatted_rates = []
+        for entry in funding_history:
+            formatted_rates.append({
+                "symbol": entry["symbol"],
+                "funding_rate": float(entry["fundingRate"]),
+                "funding_time": entry["fundingTime"],
+            })
+
+        # Sort by time descending (most recent first)
+        formatted_rates.sort(key=lambda x: x["funding_time"], reverse=True)
+
+        response = {
+            "symbol": normalized_symbol,
+            "count": len(formatted_rates),
+            "history": formatted_rates,
+        }
+
+        logger.info(f"Successfully fetched {len(formatted_rates)} funding rate entries for {symbol}")
+        return create_success_response(
+            data=response,
+            metadata={
+                "source": "binance_api",
+                "endpoint": "futures_funding_rate"
+            }
+        )
+
+    except ValueError as e:
+        error_msg = f"Invalid symbol format: {str(e)}"
+        logger.warning(f"Validation error for symbol '{symbol}': {error_msg}")
+        return create_error_response("validation_error", error_msg)
+
+    except (BinanceAPIException, BinanceRequestException) as e:
+        logger.error(f"Error fetching funding rates: {str(e)}")
+        return create_error_response("binance_api_error", f"Error fetching funding rates: {str(e)}")
+
+    except Exception as e:
+        logger.error(f"Unexpected error in get_funding_rates tool: {str(e)}")
+        return create_error_response("tool_error", f"Tool execution failed: {str(e)}")


### PR DESCRIPTION
Closes #9

Adds a `get_funding_rates` tool that retrieves funding rate history for Binance perpetual futures contracts.

## What it does

Funding rates are periodic payments between long and short traders. This tool exposes the `futures_funding_rate` endpoint from the Binance API, letting agents check:

- Current funding rate for any perpetual pair
- Historical funding rate data (up to 1000 records)
- Whether a market is crowded long (positive rate) or short (negative rate)

## Changes

- **`binance_mcp_server/tools/get_funding_rates.py`** — New tool module following the existing pattern (`rate_limited`, `validate_symbol`, `create_success_response`/`create_error_response`)
- **`binance_mcp_server/server.py`** — Registered `get_funding_rates` tool with `@mcp.tool()` decorator. Added to server instructions docstring.

## Usage

```
"Get the funding rate for BTCUSDT"
"What are the recent funding rates for ETHUSDT?"
"Show me the last 10 funding rate entries for SOLUSDT"
```

## Parameters

| Param | Type | Required | Description |
|-------|------|----------|-------------|
| `symbol` | str | Yes | Trading pair (e.g., `BTCUSDT`) |
| `limit` | int | No | Records to return (default: 100, max: 1000) |